### PR TITLE
main.goリファクタとhandlerのテスト修正

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,36 +1,26 @@
 package main
 
 import (
-	"log"
-
-	"github.com/labstack/echo/v4"
+	"github.com/sakaguchi-0725/go-todo/cmd/server"
 	"github.com/sakaguchi-0725/go-todo/internal/infrastructure/database"
 	"github.com/sakaguchi-0725/go-todo/internal/infrastructure/repository"
 	"github.com/sakaguchi-0725/go-todo/internal/interface/handler"
-	"github.com/sakaguchi-0725/go-todo/internal/interface/middleware"
 	"github.com/sakaguchi-0725/go-todo/internal/usecase"
 	"github.com/sakaguchi-0725/go-todo/pkg/config"
-	"go.uber.org/zap"
 )
 
 func main() {
 	config.LoadConfig()
-	logger, err := zap.NewProduction()
-	if err != nil {
-		log.Fatalf("Loggerの初期化に失敗しました: %v", err)
-	}
-
-	e := echo.New()
-	e.Use(middleware.LoggerMiddleware(logger))
-	e.Use(middleware.ErrorMiddleware(logger))
 	db := database.NewDB()
 
 	taskRepository := repository.NewTaskRepository(db)
 	taskUsecase := usecase.NewTaskUsecase(taskRepository)
 	taskHandler := handler.NewTaskHandler(taskUsecase)
 
-	t := e.Group("/tasks")
-	t.GET("", taskHandler.GetAllTasks)
-	t.POST("", taskHandler.CreateTask)
+	handlers := server.AppHandlers{
+		TaskHandler: taskHandler,
+	}
+
+	e := server.NewServer(handlers)
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"log"
+
+	"github.com/labstack/echo/v4"
+	"github.com/sakaguchi-0725/go-todo/internal/interface/handler"
+	"github.com/sakaguchi-0725/go-todo/internal/interface/middleware"
+	"go.uber.org/zap"
+)
+
+type AppHandlers struct {
+	TaskHandler handler.TaskHandler
+}
+
+func NewServer(handlers AppHandlers) *echo.Echo {
+	logger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("Loggerの初期化に失敗しました: %v", err)
+	}
+	e := echo.New()
+	e.Use(middleware.LoggerMiddleware(logger))
+	e.Use(middleware.ErrorMiddleware(logger))
+
+	t := e.Group("/tasks")
+	t.GET("", handlers.TaskHandler.GetAllTasks)
+	t.POST("", handlers.TaskHandler.CreateTask)
+
+	return e
+}


### PR DESCRIPTION
## 対応内容
handlerのテストでステータスコードが正しく返ってきていなかったため、middlewareの設定およびルーティングの設定をserver.goに切り出した。
NewServerメソッドではルーティングの設定とmiddlewareの設定を行ったecho.Echoをreturn するように変更したことで、handlerテストでもエラーmiddlewareを適用できるようになる。